### PR TITLE
Remove $mappingProperties for valid configuration

### DIFF
--- a/src/ElasticquentTrait.php
+++ b/src/ElasticquentTrait.php
@@ -11,10 +11,6 @@ use \Elasticquent\ElasticquentResultCollection as ResultCollection;
  */
 trait ElasticquentTrait
 {
-    /**
-     * @var array mapping properties
-     */
-    public $mappingProperties;
 
     /**
      * Uses Timestamps In Index


### PR DESCRIPTION
Sorry for the second remark. It needs to be removed completely, due to the fact that the trait is defining that variable in the "using-class". The current implementation returns the following error "App\Example and Elasticquent\ElasticquentTrait define the same property ($mappingProperties) in the composition of App\Example. However, the definition differs and is considered incompatible. Class was composed". This should be fixed now.