### PR TITLE
Add Partial-Update Function

### DIFF
--- a/src/ElasticquentTrait.php
+++ b/src/ElasticquentTrait.php
@@ -327,6 +327,21 @@ trait ElasticquentTrait
     }
 
     /**
+     * Partial Update to Indexed Document
+     *
+     * @return array
+     */
+    public function updateIndex()
+    {
+        $params = $this->getBasicEsParams();
+
+        // Get our document body data.
+        $params['body']['doc'] = $this->getIndexDocumentData();
+
+        return $this->getElasticSearchClient()->update($params);
+    }
+
+    /**
      * Get Search Document
      *
      * Retrieve an ElasticSearch document


### PR DESCRIPTION
Normally if we want to update an existing document, we have to reindex or replace it.

By ElasticSearch's [`update`](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update.html) API, it can be able to do partial updates to a document. This update API is more efficient and reliable. (See link for more information)

> The difference is that this process happens within a shard, thus avoiding the network overhead of multiple requests. By reducing the time between the retrieve and reindex steps, we also reduce the likelihood of there being conflicting changes from other processes.
   - https://www.elastic.co/guide/en/elasticsearch/guide/current/partial-updates.html

In this `updateIndex()`, existing scalar fields (columns) are overwritten, and new fields (columns) are added to the index.