### PR TITLE
Support elasticsearch php client v1 and v2.

### DIFF
--- a/src/ElasticquentClientTrait.php
+++ b/src/ElasticquentClientTrait.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Elasticquent;
+
+trait ElasticquentClientTrait
+{
+    use ElasticquentConfigTrait;
+
+    /**
+     * Get ElasticSearch Client
+     *
+     * @return \Elasticsearch\Client
+     */
+    public function getElasticSearchClient()
+    {
+        $config = $this->getElasticConfig();
+
+        // elasticsearch v2.0 using builder
+        if (class_exists('\Elasticsearch\ClientBuilder')) {
+            return \Elasticsearch\ClientBuilder::fromConfig($config);
+        }
+
+        // elasticsearch v1
+        return new \Elasticsearch\Client($config);
+    }
+
+}

--- a/src/ElasticquentCollectionTrait.php
+++ b/src/ElasticquentCollectionTrait.php
@@ -8,6 +8,8 @@
  */
 trait ElasticquentCollectionTrait
 {
+    use ElasticquentClientTrait;
+
     /**
      * Add To Index
      *
@@ -76,38 +78,4 @@ trait ElasticquentCollectionTrait
         return $this->addToIndex();
     }
 
-    /**
-     * Get ElasticSearch Client
-     *
-     * @return \Elasticsearch\Client
-     */
-    public function getElasticSearchClient()
-    {
-        $config = $this->getElasticConfig();
-
-        return new \Elasticsearch\Client($config);
-    }
-
-    /**
-     * Get the Elasticquent config
-     *
-     * @return array configuration
-     */
-    private function getElasticConfig()
-    {
-        $config = array();
-
-        // Laravel 4 support
-        if (!function_exists('config')) {
-            $config_helper = app('config');
-        } else {
-            $config_helper = config();
-        }
-
-        if ($config_helper->has('elasticquent.config')) {
-            $config = $config_helper->get('elasticquent.config');
-        }
-
-        return $config;
-    }
 }

--- a/src/ElasticquentConfigTrait.php
+++ b/src/ElasticquentConfigTrait.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Elasticquent;
+
+trait ElasticquentConfigTrait
+{
+    /**
+     * Get the Elasticquent config
+     *
+     * @param string $key the configuration key
+     * @param string $prefix filename of configuration file
+     * @return array configuration
+     */
+    protected function getElasticConfig($key = 'config', $prefix = 'elasticquent')
+    {
+        $config = array();
+
+        $key = $prefix . ($key ? '.' : '') . $key;
+
+        // Laravel 4 support
+        if (!function_exists('config')) {
+            $config_helper = app('config');
+        } else {
+            $config_helper = config();
+        }
+
+        if ($config_helper->has($key)) {
+            $config = $config_helper->get($key);
+        }
+
+        return $config;
+    }
+
+}

--- a/src/ElasticquentTrait.php
+++ b/src/ElasticquentTrait.php
@@ -11,6 +11,7 @@ use \Elasticquent\ElasticquentResultCollection as ResultCollection;
  */
 trait ElasticquentTrait
 {
+    use ElasticquentClientTrait;
 
     /**
      * Uses Timestamps In Index
@@ -49,18 +50,6 @@ trait ElasticquentTrait
     protected $documentVersion = null;
 
     /**
-     * Get ElasticSearch Client
-     *
-     * @return \Elasticsearch\Client
-     */
-    public function getElasticSearchClient()
-    {
-        $config = $this->getElasticConfig();
-
-        return new \Elasticsearch\Client($config);
-    }
-
-    /**
      * New Collection
      *
      * @param array $models
@@ -81,7 +70,7 @@ trait ElasticquentTrait
         // The first thing we check is if there
         // is an elasticquery config file and if there is a
         // default index.
-        $index_name = $this->getElasticConfig('elasticquent.default_index');
+        $index_name = $this->getElasticConfig('default_index');
 
         if (!empty($index_name)) {
             return $index_name;
@@ -608,26 +597,4 @@ trait ElasticquentTrait
         return $instance;
     }
 
-    /**
-     * Get the Elasticquent config
-     *
-     * @return array configuration
-     */
-    private function getElasticConfig($key = 'elasticquent.config')
-    {
-        $config = array();
-
-        // Laravel 4 support
-        if (!function_exists('config')) {
-            $config_helper = app('config');
-        } else {
-            $config_helper = config();
-        }
-
-        if ($config_helper->has($key)) {
-            $config = $config_helper->get($key);
-        }
-
-        return $config;
-    }
 }


### PR DESCRIPTION
Creating an elasticsearch client in Elasticsearch php v2 is using a Builder, so I implement checking if the class is exists, we will create the client from builder, if not create new instance just like the old client.

I do refactor a little in getElasticSearchClient and getElasticConfig so it isn't duplicated in the Elasticquent and ElasticquentCollection Trait.