### PR TITLE
Filter param for searchByQuery method

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -259,7 +259,7 @@ The first method is a simple term search that searches all fields.
 The second is a query based search for more complex searching needs:
 
 ```php
-    public static function searchByQuery($query = null, $aggregations = null, $sourceFields = null, $limit = null, $offset = null, $sort = null)
+    public static function searchByQuery($query = null, $filter = null, $aggregations = null, $sourceFields = null, $limit = null, $offset = null, $sort = null)
 ```
 
 **Example:**

--- a/src/ElasticquentTrait.php
+++ b/src/ElasticquentTrait.php
@@ -218,6 +218,7 @@ trait ElasticquentTrait
      * Search with a query array
      *
      * @param array $query
+     * @param array $filter
      * @param array $aggregations
      * @param array $sourceFields
      * @param int   $limit
@@ -226,7 +227,7 @@ trait ElasticquentTrait
      *
      * @return ResultCollection
      */
-    public static function searchByQuery($query = null, $aggregations = null, $sourceFields = null, $limit = null, $offset = null, $sort = null)
+    public static function searchByQuery($query = null, $filter = null, $aggregations = null, $sourceFields = null, $limit = null, $offset = null, $sort = null)
     {
         $instance = new static;
 
@@ -238,6 +239,10 @@ trait ElasticquentTrait
 
         if (!empty($query)) {
             $params['body']['query'] = $query;
+        }
+        
+        if (!empty($filter)) {
+            $params['body']['filter'] = $filter;
         }
 
         if (!empty($aggregations)) {


### PR DESCRIPTION
I am having a problem with top level filtering.

Here is the case:

I want the request body to be like this:
```
{
    "query": {
        "multi_match": {
            "query": "Aut",
            "fields": ["name", "brand", "sku"]
        }
    },
    "filter": {
            "term": {"category.id": "9"}
    },
    "aggs" : {
        "categories" : {
            "terms" : { "field" : "category.id" }
        }
    }
}
```
Due to lack of `filter` parameter, I have to deal with Elasticsearch Client by myself or write my own version of `searchByQuery` method.