### PR TITLE
Respect the Collection interface

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -424,7 +424,7 @@ $params = array(
 
 $params['body']['query']['match']['title'] = 'Moby Dick';
 
-$collection = new \Elasticquent\ElasticquentResultCollection($client->search($params), new Book);
+$collection = Book::hydrateElasticsearchResult($client->search($params));
 
 ```
 

--- a/src/ElasticquentResultCollection.php
+++ b/src/ElasticquentResultCollection.php
@@ -47,11 +47,11 @@ class ElasticquentResultCollection extends \Illuminate\Database\Eloquent\Collect
      */
     public function setMeta(array $meta)
     {
-        $this->took = $meta['took'];
-        $this->timed_out = $meta['timed_out'];
-        $this->shards = $meta['_shards'];
-        $this->hits = $meta['hits'];
-        $this->aggregations = array_get($meta, 'aggregations', []);
+        $this->took = isset($meta['took']) ? $meta['took'] : null;
+        $this->timed_out = isset($meta['timed_out']) ? $meta['timed_out'] : null;
+        $this->shards = isset($meta['_shards']) ? $meta['_shards'] : null;
+        $this->hits = isset($meta['hits']) ? $meta['hits'] : null;
+        $this->aggregations = isset($meta['aggregations']) ? $meta['aggregations'] : [];
 
         return $this;
     }

--- a/src/ElasticquentResultCollection.php
+++ b/src/ElasticquentResultCollection.php
@@ -47,11 +47,11 @@ class ElasticquentResultCollection extends \Illuminate\Database\Eloquent\Collect
      */
     public function setMeta(array $meta)
     {
-        $this->took = data_get($meta, 'took');
-        $this->timed_out = data_get($meta, 'timed_out');
-        $this->shards = data_get($meta, '_shards');
-        $this->hits = data_get($meta, 'hits');
-        $this->aggregations = data_get($meta, 'aggregations', []);
+        $this->took = $meta['took'];
+        $this->timed_out = $meta['timed_out'];
+        $this->shards = $meta['_shards'];
+        $this->hits = $meta['hits'];
+        $this->aggregations = array_get($meta, 'aggregations', []);
 
         return $this;
     }

--- a/src/ElasticquentResultCollection.php
+++ b/src/ElasticquentResultCollection.php
@@ -13,12 +13,23 @@ class ElasticquentResultCollection extends \Illuminate\Database\Eloquent\Collect
     /**
      * Create a new instance containing Elasticsearch results
      *
+     * @todo Remove backwards compatible detection at further point
+     * @deprecated Initialize with params ($results, $instance) is deprecated,
+     *    please use Model::hydrateElasticsearchResult($results).
+     *
      * @param  mixed  $items
      * @param  array  $meta
      * @return void
      */
     public function __construct($items, $meta = null)
     {
+        // Detect if arguments are old deprecated version ($results, $instance)
+        if (isset($items['hits']) and $meta instanceof \Illuminate\Database\Eloquent\Model) {
+            $instance = $meta;
+            $meta = $items;
+            $items = $instance::hydrateElasticsearchResult($meta);
+        }
+
         parent::__construct($items);
 
         // Take our result meta and map it

--- a/src/ElasticquentTrait.php
+++ b/src/ElasticquentTrait.php
@@ -263,7 +263,10 @@ trait ElasticquentTrait
 
         $result = $instance->getElasticSearchClient()->search($params);
 
-        return new \Elasticquent\ElasticquentResultCollection($result, $instance = new static);
+        $items = $result['hits']['hits'];
+        $collection = $instance->hydrateElasticquentResult($items, $result);
+
+        return $collection;
     }
 
     /**
@@ -280,7 +283,10 @@ trait ElasticquentTrait
 
         $result = $instance->getElasticSearchClient()->search($params);
 
-        return new \Elasticquent\ElasticquentResultCollection($result, $instance = new static);
+        $items = $result['hits']['hits'];
+        $collection = $instance->hydrateElasticquentResult($items, $result);
+
+        return $collection;
     }
 
     /**
@@ -302,7 +308,10 @@ trait ElasticquentTrait
 
         $result = $instance->getElasticSearchClient()->search($params);
 
-        return new \Elasticquent\ElasticquentResultCollection($result, $instance = new static);
+        $items = $result['hits']['hits'];
+        $collection = $instance->hydrateElasticquentResult($items, $result);
+
+        return $collection;
     }
 
     /**
@@ -639,6 +648,24 @@ trait ElasticquentTrait
     }
 
     /**
+     * Create a elacticquent result collection of models from plain arrays.
+     *
+     * @param  array  $items
+     * @param  array  $meta
+     * @return \Elasticquent\ElasticquentResultCollection
+     */
+    public static function hydrateElasticquentResult(array $items, $meta = null)
+    {
+        $instance = new static;
+
+        $items = array_map(function ($item) use ($instance) {
+            return $instance->newFromHitBuilder($item);
+        }, $items);
+
+        return $instance->newElasticquentResultCollection($items, $meta);
+    }
+
+    /**
      * Create a new model instance that is existing recursive.
      *
      * @param  \Illuminate\Database\Eloquent\Model  $model
@@ -722,6 +749,18 @@ trait ElasticquentTrait
                 $model->setRelation($key, $pivot);
             }
         }
+    }
+
+    /**
+     * Create a new Elasticquent Result Collection instance.
+     *
+     * @param  array  $models
+     * @param  array  $meta
+     * @return \Elasticquent\ElasticquentResultCollection
+     */
+    public function newElasticquentResultCollection(array $models = [], $meta = null)
+    {
+        return new ElasticquentResultCollection($models, $meta);
     }
 
     /**

--- a/src/ElasticquentTrait.php
+++ b/src/ElasticquentTrait.php
@@ -263,10 +263,7 @@ trait ElasticquentTrait
 
         $result = $instance->getElasticSearchClient()->search($params);
 
-        $items = $result['hits']['hits'];
-        $collection = $instance->hydrateElasticquentResult($items, $result);
-
-        return $collection;
+        return static::hydrateElasticsearchResult($result);
     }
 
     /**
@@ -283,10 +280,7 @@ trait ElasticquentTrait
 
         $result = $instance->getElasticSearchClient()->search($params);
 
-        $items = $result['hits']['hits'];
-        $collection = $instance->hydrateElasticquentResult($items, $result);
-
-        return $collection;
+        return static::hydrateElasticsearchResult($result);
     }
 
     /**
@@ -308,10 +302,7 @@ trait ElasticquentTrait
 
         $result = $instance->getElasticSearchClient()->search($params);
 
-        $items = $result['hits']['hits'];
-        $collection = $instance->hydrateElasticquentResult($items, $result);
-
-        return $collection;
+        return static::hydrateElasticsearchResult($result);
     }
 
     /**
@@ -645,6 +636,18 @@ trait ElasticquentTrait
         }
 
         return $instance;
+    }
+
+    /**
+     * Create a elacticquent result collection of models from plain elasticsearch result.
+     *
+     * @param  array  $result
+     * @return \Elasticquent\ElasticquentResultCollection
+     */
+    public static function hydrateElasticsearchResult(array $result)
+    {
+        $items = $result['hits']['hits'];
+        return static::hydrateElasticquentResult($items, $meta = $result);
     }
 
     /**


### PR DESCRIPTION
Fix collection methods e.g. map, filter, each, pluck, etc.

Inspired from [this fork](https://github.com/clowdy/Elasticquent/blob/improvements/src/ElasticquentResultCollection.php#L20)
Implement #55 
Fixed #6 #12 #47 #49