### PR TITLE
Replaced method_exists() with is_callable()

### DIFF
--- a/src/ElasticquentTrait.php
+++ b/src/ElasticquentTrait.php
@@ -689,7 +689,7 @@ trait ElasticquentTrait
         $attributes = $model->getAttributes();
 
         foreach ($attributes as $key => $value) {
-            if (method_exists($model, $key)) {
+            if (is_callable($model, $key)) {
                 $relation = $model->$key();
                 if ($relation instanceof Relation) {
                     // Check if the relation field is single model or collections


### PR DESCRIPTION
Not sure if this related to "jenssegers/mongodb": "3.0.*" but attributes from my model ('search', 'updated', 'created') passed the method_exists() but have no relations in my obj.

is_callable : Verify that the contents of a variable can be called as a function. This can check that a simple variable contains the name of a valid function, or that an array contains a properly encoded object and function name.

I have not tested this thoroughly but it has resolved my issue.