### PR TITLE
Fixed matching BelongsTo hydrate

### DIFF
--- a/src/ElasticquentTrait.php
+++ b/src/ElasticquentTrait.php
@@ -610,13 +610,13 @@ trait ElasticquentTrait
     public function newFromHitBuilder($hit = array())
     {
         $key_name = $this->getKeyName();
-        
+
         $attributes = $hit['_source'];
 
         if (isset($hit['_id'])) {
             $attributes[$key_name] = is_numeric($hit['_id']) ? intval($hit['_id']) : $hit['_id'];
         }
-        
+
         // Add fields to attributes
         if (isset($hit['fields'])) {
             foreach ($hit['fields'] as $key => $value) {
@@ -732,6 +732,10 @@ trait ElasticquentTrait
                     if ($relation instanceof Relation) {
                         // Check if the relation field is single model or collections
                         if (!static::isMultiLevelArray($value)) {
+                            if ($relation instanceof BelongsTo) {
+                                $model->{$relation->getForeignKey()} = $value[$relation->getOtherKey()];
+                            }
+                            
                             $value = [$value];
                         }
 

--- a/src/ElasticquentTrait.php
+++ b/src/ElasticquentTrait.php
@@ -6,6 +6,7 @@ use Exception;
 use ReflectionMethod;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 /**
  * Elasticquent Trait
@@ -735,7 +736,7 @@ trait ElasticquentTrait
                             if ($relation instanceof BelongsTo) {
                                 $model->{$relation->getForeignKey()} = $value[$relation->getOtherKey()];
                             }
-                            
+
                             $value = [$value];
                         }
 


### PR DESCRIPTION
Started working with the new recursive hydrator. This works great except for the BelongsTo relation.

This relationship matches the model back on the foreignKey, see \Illuminate\Database\Eloquent\Relations\BelongsTo line 215/222