### PR TITLE
Fix Relationship loading if there are no relationships found

### DIFF
--- a/src/ElasticquentTrait.php
+++ b/src/ElasticquentTrait.php
@@ -688,6 +688,9 @@ trait ElasticquentTrait
         $instance = $model;
 
         $items = array_map(function ($item) use ($instance, $parentRelation) {
+            // Convert all null relations into empty arrays
+            $item = $item ?: [];
+            
             return static::newFromBuilderRecursive($instance, $item, $parentRelation);
         }, $items);
 
@@ -712,7 +715,7 @@ trait ElasticquentTrait
 
                     if ($relation instanceof Relation) {
                         // Check if the relation field is single model or collections
-                        if (!static::isMultiLevelArray($value)) {
+                        if (is_null($value) === true || !static::isMultiLevelArray($value)) {
                             $value = [$value];
                         }
 


### PR DESCRIPTION
Currently we can successfully index a full collection with its respective relationships (some exist and some simply return `null) in laravel.


Here we are adding small amount of checking and a fix for when we have indexed a relationship as a `null` value (as returned from laravel)

example: 
```
>>> App\Models\SomeModel::with('relationship_name')->find(1231)

=> App\Models\ASN {#831
     id: 121,
     name: "Hello World",
     relationship_name: null
   }

```