### PR TITLE
Set empty relations as loaded too and prevent unnecessary database queries.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "elasticquent/elasticquent",
+  "name": "mendicm/elasticquent",
   "type": "library",
   "description": "Maps Laravel Eloquent models to Elasticsearch types.",
   "keywords": [

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "php": ">=5.4.0",
     "illuminate/database": "~4.2|^5",
     "illuminate/config": "~4.2|^5",
-    "nesbot/carbon": "~1.0",
+    "nesbot/carbon": "~1.0|^2",
     "elasticsearch/elasticsearch": "~6.0"
   },
   "require-dev": {

--- a/src/ElasticquentTrait.php
+++ b/src/ElasticquentTrait.php
@@ -5,6 +5,7 @@ namespace Elasticquent;
 use Exception;
 use ReflectionMethod;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Relations\Relation;
 
 /**

--- a/src/ElasticquentTrait.php
+++ b/src/ElasticquentTrait.php
@@ -744,7 +744,7 @@ trait ElasticquentTrait
         $attributes = $model->getAttributes();
 
         foreach ($attributes as $key => $value) {
-            if ($key === 'pivot') {
+            if ($key === 'pivot' && $parentRelation) {
                 unset($model[$key]);
                 $pivot = $parentRelation->newExistingPivot($value);
                 $model->setRelation($key, $pivot);

--- a/src/ElasticquentTrait.php
+++ b/src/ElasticquentTrait.php
@@ -724,6 +724,12 @@ trait ElasticquentTrait
                         // Unset attribute before match relation
                         unset($model[$key]);
                         $relation->match([$model], $models, $key);
+                        
+                        // The match method doesn't set the relation as loaded if the $models collection is empty
+                        // Set the relation as loaded manually and avoid future database queries
+                        if ((count($value) == 1 && reset($value) === null) || empty($value)) {
+                            $model->setRelation($key, empty($value) ? new Collection() : null);
+                        }
                     }
                 }
             }

--- a/src/ElasticquentTrait.php
+++ b/src/ElasticquentTrait.php
@@ -707,7 +707,7 @@ trait ElasticquentTrait
                 $reflection_method = new ReflectionMethod($model, $key);
 
                 // Check if method class has or inherits Illuminate\Database\Eloquent\Model
-                if(!static::isClassInClass("Illuminate\Database\Eloquent\Model", $reflection_method->class)) {
+                if(static::isClassInClass("Illuminate\Database\Eloquent\Model", $reflection_method->class)) {
                     $relation = $model->$key();
 
                     if ($relation instanceof Relation) {


### PR DESCRIPTION
When accessing a relation via the magic __get method on Elasticquent loaded model, unnecessary queries to the datatabase are performed if the relation is empty,. For example:

``` php
$product = Product::search('product_slug')->first();
$properties = $product->properties;
```

If the properties related model (BelongsToMany relationship) is an empty array on ElasticSearch document the relation on the $product model isn't loaded and a query to the database is performed. With this fix we prevent this unnecessary queries.
