### PR TITLE
1.0.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,10 +18,10 @@
   ],
   "require": {
     "php": ">=5.4.0",
-    "illuminate/database": "~4.2|^5",
-    "illuminate/config": "~4.2|^5",
+    "illuminate/database": "~5.3",
+    "illuminate/config": "~5.3",
     "nesbot/carbon": "~1.0",
-    "elasticsearch/elasticsearch": ">1.0 <2.2"
+    "elasticsearch/elasticsearch": "~5.1"
   },
   "require-dev": {
     "phpunit/phpunit": "~4.2|~5.0",

--- a/src/ElasticquentTrait.php
+++ b/src/ElasticquentTrait.php
@@ -591,13 +591,13 @@ trait ElasticquentTrait
     public function newFromHitBuilder($hit = array())
     {
         $key_name = $this->getKeyName();
-        
+
         $attributes = $hit['_source'];
 
         if (isset($hit['_id'])) {
             $attributes[$key_name] = is_numeric($hit['_id']) ? intval($hit['_id']) : $hit['_id'];
         }
-        
+
         // Add fields to attributes
         if (isset($hit['stored_fields'])) {
             foreach ($hit['stored_fields'] as $key => $value) {
@@ -690,7 +690,7 @@ trait ElasticquentTrait
         $items = array_map(function ($item) use ($instance, $parentRelation) {
             // Convert all null relations into empty arrays
             $item = $item ?: [];
-            
+
             return static::newFromBuilderRecursive($instance, $item, $parentRelation);
         }, $items);
 

--- a/src/ElasticquentTrait.php
+++ b/src/ElasticquentTrait.php
@@ -402,7 +402,7 @@ trait ElasticquentTrait
 
         $fields = $this->buildFieldsParameter($getSourceIfPossible, $getTimestampIfPossible);
         if (!empty($fields)) {
-            $params['stored_fields'] = implode(',', $fields);
+            $params['fields'] = implode(',', $fields);
         }
 
         if (is_numeric($limit)) {
@@ -622,8 +622,8 @@ trait ElasticquentTrait
         }
 
         // Add fields to attributes
-        if (isset($hit['stored_fields'])) {
-            foreach ($hit['stored_fields'] as $key => $value) {
+        if (isset($hit['fields'])) {
+            foreach ($hit['fields'] as $key => $value) {
                 $attributes[$key] = $value;
             }
         }

--- a/src/ElasticquentTrait.php
+++ b/src/ElasticquentTrait.php
@@ -379,7 +379,7 @@ trait ElasticquentTrait
 
         $fields = $this->buildFieldsParameter($getSourceIfPossible, $getTimestampIfPossible);
         if (!empty($fields)) {
-            $params['fields'] = implode(',', $fields);
+            $params['stored_fields'] = implode(',', $fields);
         }
 
         if (is_numeric($limit)) {
@@ -599,8 +599,8 @@ trait ElasticquentTrait
         }
         
         // Add fields to attributes
-        if (isset($hit['fields'])) {
-            foreach ($hit['fields'] as $key => $value) {
+        if (isset($hit['stored_fields'])) {
+            foreach ($hit['stored_fields'] as $key => $value) {
                 $attributes[$key] = $value;
             }
         }

--- a/src/ElasticquentTrait.php
+++ b/src/ElasticquentTrait.php
@@ -248,7 +248,7 @@ trait ElasticquentTrait
     {
         $instance = new static;
 
-        $params = $instance->getBasicEsParams(true, true, true, $limit, $offset);
+        $params = $instance->getBasicEsParams(true, false, false, $limit, $offset);
 
         if (!empty($sourceFields)) {
             $params['body']['_source']['include'] = $sourceFields;

--- a/src/config/elasticquent.php
+++ b/src/config/elasticquent.php
@@ -29,4 +29,26 @@ return array(
 
     'default_index' => 'my_custom_index_name',
 
+    /*
+    |--------------------------------------------------------------------------
+    | Toggle syncing of Eloquent Models to Elastic Index
+    |--------------------------------------------------------------------------
+    |
+    | Update Elastic index each time a model is saved/created/deleted
+    |
+    */
+    'sync' => false,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Eloquent Results
+    |--------------------------------------------------------------------------
+    | Options:
+    |   True  : The results of ElasticSearch will be converted to actual eloquent models from live database
+    |   False : The results of ElasticSearch will not query the live database but instead use the _source properties
+    |           and convert to Eloquent model. Your ElasticSearch mapping must contain all information you need since
+    |           methods will not be loaded if there are missing properties.
+    |
+    */
+    'use_live' => false,
 );


### PR DESCRIPTION
* Update to elasticsearch 5.1 & laravel 5.3
* Removed trailing spaces
* Added feature "sync" and "live"
* Added "sync" and "live" to config
* Disable forced parameters when using searchByQuery since "fields" query has been disabled in ElasticSearch 5.0
* Sync feature will automatically update the Elastic index when there are created/saved/deleted events from Eloquent models
* Live feature allows to return Eloquent models from ElasticSearch results