### PR TITLE
Fix related to bug #69

### DIFF
--- a/src/ElasticquentTrait.php
+++ b/src/ElasticquentTrait.php
@@ -710,7 +710,8 @@ trait ElasticquentTrait
             if (method_exists($model, $key)) {
                 $reflection_method = new ReflectionMethod($model, $key);
 
-                if ($reflection_method->class != "Illuminate\Database\Eloquent\Model") {
+                // Check if method class has or inherits Illuminate\Database\Eloquent\Model
+                if(!static::isClassInClass("Illuminate\Database\Eloquent\Model", $reflection_method->class)) {
                     $relation = $model->$key();
 
                     if ($relation instanceof Relation) {
@@ -778,4 +779,36 @@ trait ElasticquentTrait
         }
         return true;
     }
+
+    /**
+     * Check the hierarchy of the given class (including the given class itself)
+     * to find out if the class is part of the other class.
+     *
+     * @param $classNeedle
+     * @param $classHaystack
+     * @return bool
+     */
+    private static function isClassInClass($classNeedle, $classHaystack)
+    {
+        // Check for the same
+        if($classNeedle == $classHaystack) {
+            return true;
+        }
+
+        // Check for parent
+        $classHaystackReflected = new \ReflectionClass($classHaystack);
+        while ($parent = $classHaystackReflected->getParentClass()) {
+            /**
+             * @var \ReflectionClass $parent
+             */
+            if($parent->getName() == $classNeedle) {
+                return true;
+            }
+            $classHaystackReflected = $parent;
+        }
+
+        return false;
+
+    }
+
 }

--- a/src/ElasticquentTrait.php
+++ b/src/ElasticquentTrait.php
@@ -784,8 +784,8 @@ trait ElasticquentTrait
      * Check the hierarchy of the given class (including the given class itself)
      * to find out if the class is part of the other class.
      *
-     * @param $classNeedle
-     * @param $classHaystack
+     * @param string $classNeedle
+     * @param string $classHaystack
      * @return bool
      */
     private static function isClassInClass($classNeedle, $classHaystack)


### PR DESCRIPTION
The bug fixed in my case. Hope that fixes the entire bug for others as well. Can somebody confirm?
https://github.com/elasticquent/Elasticquent/issues/69

I was using models extended from several of my own model-like classes then extended from \Eloquent then extended from Illuminate\Database\Eloquent\Model. Several-levels of inheritence was the problem in my case. In some of models I was using "hasOne" instead of "belongsToMany" relation, but the logic of the code was still directing to methods of "vendor\laravel\framework\src\Illuminate\Database\Eloquent\Relations\BelongsToMany.php" which is not right (?).

The check for parent classes was included into the logic to make sure the model is part of "Illuminate\Database\Eloquent\Model".

Laravel 4.2, Elastic search 1.7.5.
All should work with newer versions as well.

p.s. That is the very first push to an open source project started by others. Feel free to teach me if I did something wrong in here.