### PR TITLE
Resolve a problem whereby a large amount of data for a given model wo…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ composer.phar
 composer.lock
 .DS_Store
 Thumbs.db
+.idea


### PR DESCRIPTION
Resolve a problem whereby a large amount of data for a given model would result in a "Request size exceeded 10485760 bytes" error in AWS Elastic Search (and potentially other configurations)

Ran into this issue today, quite annoying. I re-factored the code to send the data in lots of 1000 database records/models, and it works like a charm.