### PR TITLE
bug fix for #149

### DIFF
--- a/src/ElasticquentTrait.php
+++ b/src/ElasticquentTrait.php
@@ -665,7 +665,9 @@ trait ElasticquentTrait
     {
         $instance = $model->newInstance([], $exists = true);
 
-        $instance->setRawAttributes((array)$attributes, $sync = true);
+        foreach($attributes as $k=>$v) {
+            $instance->setAttribute($k, $v);
+        }
 
         // Load relations recursive
         static::loadRelationsAttributesRecursive($instance);


### PR DESCRIPTION
Uses the models setAttribute($key, $value) method to allow the model to properly hydrate, casting Dates and Json to appropriate types and calling any custom set mutators on the model.