### PR TITLE
Fix Travis tests and composer requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,17 @@
 language: php
 
 php:
-    - 5.5
-    - 5.6
+    - 7.0
+    - 7.1
+    - 7.2
 
-include:
-    - php: 5.5
-      env: dependencies=lowest
+matrix:
+    include:
+        - php: 7.0
+          env: dependencies=lowest
 
 before_script:
     - composer self-update
-    - composer install --prefer-source --no-interaction --dev
-    - if [ "$dependencies" = "lowest" ]; then composer update --prefer-lowest --prefer-stable -n; fi;
+    - if [ -z "$dependencies" ]; then composer update --prefer-source --no-interaction; fi;
+    - if [ "$dependencies" = "lowest" ]; then composer update --prefer-lowest --prefer-stable --no-interaction; fi;
 

--- a/composer.json
+++ b/composer.json
@@ -17,14 +17,14 @@
     }
   ],
   "require": {
-    "php": ">=5.4.0",
-    "illuminate/database": "~4.2|^5",
-    "illuminate/config": "~4.2|^5",
+    "php": "^7",
+    "illuminate/database": "^5",
+    "illuminate/config": "^5",
     "nesbot/carbon": "~1.0",
     "elasticsearch/elasticsearch": "~6.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "~4.2|~5.0",
+    "phpunit/phpunit": "^5",
     "mockery/mockery": "^0.9.4"
   },
   "autoload": {


### PR DESCRIPTION
The change to ES ~6.0 raised requirements to PHP 7.x, but Travis was testing at PHP 5.5/5.6.

I updated composer.json to the lowest dependencies that passed phpunit, fixed Travis config to include testing against lowest dependencies, and changed the non-lowest dependencies test command for consistency.