### PR TITLE
Type String is now replaced with text in Elasticsearch

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -212,7 +212,7 @@ For mapping, you can set a `mappingProperties` property in your model and use so
 ```php
 protected $mappingProperties = array(
    'title' => array(
-        'type' => 'string',
+        'type' => 'text',
         'analyzer' => 'standard'
     )
 );


### PR DESCRIPTION
Source: https://www.elastic.co/blog/strings-are-dead-long-live-strings