### PR TITLE
Fixed integer _id checking

### DIFF
--- a/src/ElasticquentTrait.php
+++ b/src/ElasticquentTrait.php
@@ -590,8 +590,7 @@ trait ElasticquentTrait
         $attributes = $hit['_source'];
 
         if (isset($hit['_id'])) {
-            $idAsInteger = intval($hit['_id']);
-            $attributes[$key_name] = $idAsInteger ? $idAsInteger : $hit['_id'];
+            $attributes[$key_name] = is_int($hit['_id']) ? intval($hit['_id']) : $hit['_id'];
         }
         
         // Add fields to attributes


### PR DESCRIPTION
This is a correction to PR #211 for Issue #210.

// (original) BAD -- that other guy's mongo ID gets identified as numeric
is_numeric('5e2736479201327028213292') // true
is_numeric('18bd34a7223c6e2fb831a15e0384b153') //false

// (#211) BAD -- can't check non-zero intval because intval mangles my UUIDs
intval('5e2736479201327028213292') // 0
intval('18bd34a7223c6e2fb831a15e0384b153') // 18

// GOOD - both are identified as non-integer
is_int('5e2736479201327028213292') // false
is_int('18bd34a7223c6e2fb831a15e0384b153') // false