### PR TITLE
Support Laravel 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,14 +17,12 @@
     }
   ],
   "require": {
-    "php": ">=5.4.0",
-    "illuminate/database": "~4.2|^5|^6|^7",
-    "illuminate/config": "~4.2|^5|^6|^7",
+    "php": ">=7.3.0",
     "nesbot/carbon": "~1.0|~2",
     "elasticsearch/elasticsearch": "~6.1"
   },
   "require-dev": {
-    "phpunit/phpunit": "~4.2|~5.0|~8.0",
+    "phpunit/phpunit": "~4.2|~5.0|~8.0|^9.0",
     "mockery/mockery": "^0.9.4|^1.0"
   },
   "autoload": {


### PR DESCRIPTION
Hello. I see that there are support requests to support Laravel 8. By making these simple changes to composer.json, our company is able to use Elasticquent in production on Laravel 8.x.